### PR TITLE
Add _removedHeader property to response object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,9 @@ function createReq(path,options){
     return req
 }
 function createRes(callback){
-	var res={}
+	var res={
+		_removedHeader: {}
+	}
 	// res=_.extend(res,require('express/lib/response'));
 
 	var headers={}


### PR DESCRIPTION
Resolves a crash upon triggering redirected requests when using express 4.16.2.