### PR TITLE
Add support for statusCode in responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,15 @@ function createReq(path, options) {
 function createRes(callback) {
   var res = {
     _removedHeader: {},
+    _statusCode: 200,
+    statusMessage: 'OK',
+    get statusCode() {
+      return this._statusCode
+    },
+    set statusCode(status) {
+      this._statusCode = status
+      this.status(status)
+    }
   };
   // res=_.extend(res,require('express/lib/response'));
 
@@ -96,7 +105,8 @@ function createRes(callback) {
     res.end();
     // callback(code,url)
   };
-  res.status = function(number) {
+  res.status = res.sendStatus = function(number) {
+    console.log('[runMiddleware] res.status', number, res);
     code = number;
     return res;
   };

--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ function createRes(callback) {
     // callback(code,url)
   };
   res.status = res.sendStatus = function(number) {
-    console.log('[runMiddleware] res.status', number, res);
     code = number;
     return res;
   };


### PR DESCRIPTION
This allows to test the statusCode within the callback and get whatever was set during the middleware execution.

This is merely a shim for the `statusCode` and `statusMessage` properties of the `Response` object. A full adoption of the `Response` object would require more tests.