### PR TITLE
Adding function getHeaders to prevent TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ function createRes(callback) {
     headers[x.toLowerCase()] = y;
     return res;
   };
+  res.getHeader = (x) => headers[x];
   // res.get=(x) => {
   // 	return headers[x]
   // }


### PR DESCRIPTION
When using express 4.17.1 and custom headers the express
endpoint call would throw the TypeError: Cannot read property 'etag' of undefined
as the getHeaders function is missing